### PR TITLE
Prevents Scheduled Workflow From Being Deactivated & [IBCDPE-898] Fix Python Versioning Issue for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,10 @@ jobs:
           name: python-distribution-files
           path: dist/
           retention-days: 1
+      - name: Keepalive Workflow
+        uses: gautamkrishnar/keepalive-workflow@1.1.0
+        with:
+          time_elapsed: 44
 
   test:
     needs: prepare

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,14 +67,16 @@ jobs:
         - macos-latest
         # TODO: Debug the Windows issues
         # - windows-latest
+    env:
+      OS: ${{ matrix.platform }}
+      PYTHON: ${{ matrix.python }}    
     runs-on: ${{ matrix.platform }}
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}
-      - name: Retrieve pre-built distribution files
-        uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v3
         with: {name: python-distribution-files, path: dist/}
       - name: Install tox-gh plugin
         run: python -m pip install tox-gh>=1.2
@@ -85,8 +87,7 @@ jobs:
         env:
           SYNAPSE_AUTH_TOKEN: ${{ secrets.SYNAPSE_AUTH_TOKEN }}
         run: >-
-          pipx run --spec 'tox~=3.0' tox
-          --installpkg '${{ needs.prepare.outputs.wheel-path }}'
+          tox --installpkg '${{ needs.prepare.outputs.wheel-path }}'
           -- -rFEx --durations 10 --color yes -m "not integration"
       - name: Run tests (with integration tests)
         if: matrix.platform == 'ubuntu-latest' && matrix.python == '3.11'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
         # - windows-latest
     env:
       OS: ${{ matrix.platform }}
-      PYTHON: ${{ matrix.python }}    
+      PYTHON: ${{ matrix.python }}
     runs-on: ${{ matrix.platform }}
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
     strategy:
       matrix:
         python:
-        - "3.8"  # oldest Python that is supported
+        - "3.9"  # oldest Python that is supported
         - "3.11"  # newest Python that is stable
         platform:
         - ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,8 +32,10 @@ jobs:
         with: {python-version: "3.11"}
       - name: Run static analysis and format checkers
         run: pipx run pre-commit run --all-files --show-diff-on-failure
+      - name: Install tox-gh plugin
+        run: python -m pip install tox-gh>=1.2
       - name: Build package distribution files
-        run: pipx run --spec 'tox~=3.0' tox -e clean,build
+        run: tox -e clean,build
       - name: Record the paths of wheel and source tarball distributions
         id: distribution-paths
         run: |
@@ -58,7 +60,7 @@ jobs:
     strategy:
       matrix:
         python:
-        - "3.9"
+        - "3.8"  # oldest Python that is supported
         - "3.11"  # newest Python that is stable
         platform:
         - ubuntu-latest
@@ -74,6 +76,10 @@ jobs:
       - name: Retrieve pre-built distribution files
         uses: actions/download-artifact@v3
         with: {name: python-distribution-files, path: dist/}
+      - name: Install tox-gh plugin
+        run: python -m pip install tox-gh>=1.2
+      - name: Setup test suite
+        run: tox -vv --notest
       - name: Run tests (without integration tests)
         if: matrix.platform != 'ubuntu-latest' || matrix.python != '3.11'
         env:
@@ -87,8 +93,7 @@ jobs:
         env:
           SYNAPSE_AUTH_TOKEN: ${{ secrets.SYNAPSE_AUTH_TOKEN }}
         run: >-
-          pipx run --spec 'tox~=3.0' tox
-          --installpkg '${{ needs.prepare.outputs.wheel-path }}'
+          tox --installpkg '${{ needs.prepare.outputs.wheel-path }}'
           -- -rFEx --durations 10 --color yes
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
     strategy:
       matrix:
         python:
-        - "3.8"
+        - "3.9"
         - "3.11"  # newest Python that is stable
         platform:
         - ubuntu-latest

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -17,7 +17,7 @@ formats:
   - pdf
 
 python:
-  version: 3.8
+  version: 3.9
   install:
     - requirements: docs/requirements.txt
     - {path: ., method: pip}

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,7 +41,7 @@ package_dir =
     =src
 
 # Require a min/specific Python version (comma-separated conditions)
-python_requires = >=3.8
+python_requires = >=3.9
 
 # Add here dependencies of your project (line-separated), e.g. requests>=2.2,<3.0.
 # Version specifiers like >=2.2,<3.0 avoid problems due to API changes in

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,7 +41,7 @@ package_dir =
     =src
 
 # Require a min/specific Python version (comma-separated conditions)
-python_requires = >=3.9
+python_requires = >=3.8, <3.12
 
 # Add here dependencies of your project (line-separated), e.g. requests>=2.2,<3.0.
 # Version specifiers like >=2.2,<3.0 avoid problems due to API changes in

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,7 +41,7 @@ package_dir =
     =src
 
 # Require a min/specific Python version (comma-separated conditions)
-python_requires = >=3.8, <3.12
+python_requires = >=3.9, <3.12
 
 # Add here dependencies of your project (line-separated), e.g. requests>=2.2,<3.0.
 # Version specifiers like >=2.2,<3.0 avoid problems due to API changes in

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@ minversion = 4.2
 isolated_build = True
 
 [gh]
-python = 
+python =
     3.8: py38
     3.9: py39
     3.10: py310

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,6 @@ isolated_build = True
 
 [gh]
 python =
-    3.8: py38
     3.9: py39
     3.10: py310
     3.11: py311

--- a/tox.ini
+++ b/tox.ini
@@ -3,10 +3,15 @@
 # THIS SCRIPT IS SUPPOSED TO BE AN EXAMPLE. MODIFY IT ACCORDING TO YOUR NEEDS!
 
 [tox]
-minversion = 3.24
-envlist = default
+minversion = 4.2
 isolated_build = True
 
+[gh]
+python = 
+    3.8: py38
+    3.9: py39
+    3.10: py310
+    3.11: py311
 
 [testenv]
 description = Invoke pytest to run automated tests


### PR DESCRIPTION
**Problem:**

Github by default will disable scheduled Actions on repositories that have had no commits for >50 days. This presents a problem for repos such as `fs-synapse` which are still actively used but may not have frequent commits. When the workflow is deactivated, it also prevents normal runs from happening when you push new changes to a PR or into `main` until you reactivate it. 

**Solution:**

Add the [keepalive-workflow](https://github.com/gautamkrishnar/keepalive-workflow) to our CI pipeline to prevent our scheduled action from ever becoming paused.

[IBCDPE-898]
**Problem:**

Similar to `py-orca`, this repository was initially setup incorrectly with `tox`, causing the test environments created by the CI pipeline to use the wrong Python versions.

**Solution:**

Implement the same fix as [here](https://github.com/Sage-Bionetworks-Workflows/py-orca/pull/31) to enable testing with the correct Python versions in GitHub Actions.

**Notes:**
- I have also removed support for Python 3.8 for `fs-synapse`. There are a number of subscripted types in the type-hints of the package and I figured this made more sense than making the changes needed to support 3.8, especially given that this will be included in the new `fs-synapse` major version
 

[IBCDPE-898]: https://sagebionetworks.jira.com/browse/IBCDPE-898?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ