### PR TITLE
Adds `gh_token` to KeepAlive GH Action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,7 @@ jobs:
         uses: gautamkrishnar/keepalive-workflow@1.1.0
         with:
           time_elapsed: 44
+          gh_token: ${{ secrets.GITHUB_TOKEN }}
 
   test:
     needs: prepare


### PR DESCRIPTION
This PR adds the `gh_token` parameter to the `keepalive-workflow` which prevents the scheduled CI workflow from being paused if there are no commits to this repository for more than 60 days. I am not sure why this was working before and only recently began failing, but this should prevent this from being an issue in the future. 